### PR TITLE
Start using SimbolicScope and add Symbol to all Decl

### DIFF
--- a/tmplang/include/tmplang/Lowering/Dialect/IR/TmplangOps.td
+++ b/tmplang/include/tmplang/Lowering/Dialect/IR/TmplangOps.td
@@ -163,5 +163,4 @@ def ReturnOp : Tmplang_Op<"return", [NoSideEffect, HasParent<"SubprogramOp">,
   let hasVerifier = 1;
 }
 
-
 #endif // TMPLANG_OPS

--- a/tmplang/include/tmplang/Tree/HIR/Decl.h
+++ b/tmplang/include/tmplang/Tree/HIR/Decl.h
@@ -11,9 +11,15 @@ class Node;
 
 namespace tmplang::hir {
 
+// Forward declarations
+class Symbol;
+class Type;
+
 class Decl : public Node {
 public:
-  StringRef getName() const { return Name; }
+  StringRef getName() const;
+  const Symbol &getSymbol() const { return Sym; }
+  virtual const Type &getType() const;
 
   static bool classof(const Node *node) {
     return node->getKind() == Node::Kind::SubprogramDecl ||
@@ -23,12 +29,11 @@ public:
   virtual ~Decl() = default;
 
 protected:
-  explicit Decl(Node::Kind k, const source::Node &srcNode, StringRef name)
-      : Node(k, srcNode), Name(name) {}
+  explicit Decl(Node::Kind k, const source::Node &srcNode, const Symbol &sym)
+      : Node(k, srcNode), Sym(sym) {}
 
 private:
-  /// All Decls have a name
-  SmallString<32> Name;
+  const Symbol &Sym;
 };
 
 } // namespace tmplang::hir

--- a/tmplang/include/tmplang/Tree/HIR/Decls.h
+++ b/tmplang/include/tmplang/Tree/HIR/Decls.h
@@ -15,19 +15,13 @@ class Type;
 
 class ParamDecl final : public Decl {
 public:
-  const Type &getType() const { return ParamType; }
-
   static bool classof(const Node *node) {
     return node->getKind() == Node::Kind::ParamDecl;
   }
 
-  explicit ParamDecl(const source::Node &srcNode, StringRef name,
-                     const Type &paramType)
-      : Decl(Node::Kind::ParamDecl, srcNode, name), ParamType(paramType) {}
+  explicit ParamDecl(const source::Node &srcNode, const Symbol &sym)
+      : Decl(Node::Kind::ParamDecl, srcNode, sym) {}
   virtual ~ParamDecl() = default;
-
-private:
-  const Type &ParamType;
 };
 
 class SubprogramDecl final : public Decl {
@@ -37,8 +31,8 @@ public:
     fn        // non-pure function
   };
 
+  const SubprogramType &getType() const override;
   FunctionKind getFunctionKind() const { return FuncKind; }
-  const SubprogramType &getSubprogramType() const { return SubprogramType; }
   ArrayRef<ParamDecl> getParams() const { return Params; }
   ArrayRef<std::unique_ptr<Expr>> getBody() const { return Expressions; }
 
@@ -46,20 +40,17 @@ public:
     return node->getKind() == Node::Kind::SubprogramDecl;
   }
 
-  explicit SubprogramDecl(const source::Node &srcNode, StringRef name,
-                          FunctionKind kind, const SubprogramType &subprogramTy,
-                          std::vector<ParamDecl> params,
+  explicit SubprogramDecl(const source::Node &srcNode, const Symbol &sym,
+                          FunctionKind kind, std::vector<ParamDecl> params,
                           std::vector<std::unique_ptr<Expr>> exprs)
-      : Decl(Node::Kind::SubprogramDecl, srcNode, name), FuncKind(kind),
-        SubprogramType(subprogramTy), Params(std::move(params)),
-        Expressions(std::move(exprs)) {}
+      : Decl(Node::Kind::SubprogramDecl, srcNode, sym), FuncKind(kind),
+        Params(std::move(params)), Expressions(std::move(exprs)) {}
   virtual ~SubprogramDecl() = default;
 
   SubprogramDecl(SubprogramDecl &&subprogramDecl) = default;
 
 private:
   FunctionKind FuncKind;
-  const SubprogramType &SubprogramType;
   std::vector<ParamDecl> Params;
   std::vector<std::unique_ptr<Expr>> Expressions;
 };

--- a/tmplang/include/tmplang/Tree/HIR/HIRContext.h
+++ b/tmplang/include/tmplang/Tree/HIR/HIRContext.h
@@ -2,6 +2,7 @@
 #define TMPLANG_TREE_HIR_HIRCONTEXT_H
 
 #include <llvm/ADT/IntrusiveRefCntPtr.h>
+#include <tmplang/Tree/HIR/Symbol.h>
 #include <tmplang/Tree/HIR/Types.h>
 
 #include <deque>
@@ -12,6 +13,8 @@ class HIRContext : llvm::RefCountedBase<HIRContext> {
 public:
   explicit HIRContext();
   ~HIRContext() = default;
+
+  SymbolManager &getSymbolManager() { return SymM; }
 
 private:
   friend class BuiltinType;
@@ -25,6 +28,8 @@ private:
 
   std::deque<TupleType> TupleTypes;
   std::deque<SubprogramType> SubprogramTypes;
+
+  SymbolManager SymM;
 };
 
 } // namespace tmplang::hir

--- a/tmplang/include/tmplang/Tree/HIR/Symbol.h
+++ b/tmplang/include/tmplang/Tree/HIR/Symbol.h
@@ -1,0 +1,119 @@
+#ifndef TMPLANG_TREE_HIR_SYMBOL_H
+#define TMPLANG_TREE_HIR_SYMBOL_H
+
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/Allocator.h>
+
+namespace tmplang::hir {
+
+/// Foward declarations
+class SymbolicScope;
+class Symbol;
+class Type;
+class HIRContext;
+
+enum class SymbolKind {
+  /// Initial state of symbols that are unknown when queried. It is considered
+  /// and error if after the resolving symbols pass any of these remains.
+  Unresolved = 0,
+  Subprogram,
+  ParamOrVarDecl
+};
+llvm::StringLiteral ToString(SymbolKind);
+
+/// Represent a space where
+class SymbolicScope {
+public:
+  /// All except the global scope has a containing scope
+  const SymbolicScope &getContainingScope() const;
+  bool isGlobalScope() const;
+
+  bool containsSymbol(const Symbol &sym) const;
+  bool containsSymbol(SymbolKind kind, llvm::StringRef id) const;
+
+  [[maybe_unused]] Symbol &addSymbol(Symbol &);
+
+  void dump(bool recursively = false) const;
+
+  llvm::ArrayRef<std::reference_wrapper<Symbol>> getSymbols() const {
+    return Symbols;
+  }
+
+private:
+  /// Only the SymbolManager can build Scopes
+  friend class SymbolManager;
+
+  /// Non-global scope constructor
+  SymbolicScope(const SymbolicScope &parentScope) : ParentScope(&parentScope) {}
+
+  /// Global scope constructor
+  SymbolicScope() : ParentScope(nullptr) {}
+
+private:
+  /// All scopes except the GlobalScope have a parent scope
+  const SymbolicScope *ParentScope;
+  /// TODO: Profile about a nice initial size for the array
+  llvm::SmallVector<std::reference_wrapper<Symbol>> Symbols;
+};
+
+class Symbol {
+public:
+  SymbolKind getKind() const { return Kind; }
+  llvm::StringRef getId() const { return Id; }
+  const Type &getType() const { return Ty; }
+
+  bool operator==(const Symbol &) const;
+
+private:
+  /// Only the SymbolManager can build Symbols
+  friend class SymbolManager;
+
+  /// Non-unresolvedSymbol constructor
+  Symbol(const SymbolKind kind, llvm::StringRef id, const Type &ty)
+      : Kind(kind), Id(id), Ty(ty) {}
+
+  /// UnresolvedSymbol constructor
+  /// It has unit type, althouhg it does not matter
+  Symbol(const SymbolicScope &parentScope, const HIRContext &ctx);
+
+private:
+  /// The kind of this symbol
+  const SymbolKind Kind;
+  /// All symbols have an identifier
+  llvm::StringRef Id;
+  /// All symbols have a type
+  const Type &Ty;
+};
+
+class SymbolManager {
+public:
+  SymbolManager(HIRContext &ctx)
+      : GlobalScope(), UnresolvedSymbol(GlobalScope, ctx) {}
+
+  SymbolicScope &getGlobalScope() { return GlobalScope; }
+  const Symbol &getUnresolvedSymbol() const { return UnresolvedSymbol; }
+
+  Symbol &createSymbol(const SymbolKind kind, llvm::StringRef id,
+                       const Type &ty) {
+    return *new (SymbolArena.Allocate()) Symbol(kind, id, ty);
+  }
+
+  SymbolicScope &createSymbolicScope(const SymbolicScope &parentScope) {
+    return *new (SymbolicScopeArena.Allocate()) SymbolicScope(parentScope);
+  }
+
+private:
+  SymbolicScope GlobalScope;
+  /// Symbol that has been not yet resolved. If any node still contains this
+  /// node after resolving all symbols, means that there is a problem.
+  const Symbol UnresolvedSymbol;
+
+  /// Arenas that will store Symbols and Scopes
+  llvm::SpecificBumpPtrAllocator<Symbol> SymbolArena;
+  llvm::SpecificBumpPtrAllocator<SymbolicScope> SymbolicScopeArena;
+};
+
+} // namespace tmplang::hir
+
+#endif // TMPLANG_TREE_HIR_SYMBOL_H

--- a/tmplang/include/tmplang/Tree/HIR/Type.h
+++ b/tmplang/include/tmplang/Tree/HIR/Type.h
@@ -1,6 +1,10 @@
 #ifndef TMPLANG_TREE_HIR_TYPE_H
 #define TMPLANG_TREE_HIR_TYPE_H
 
+namespace llvm {
+class raw_ostream;
+} // namespace llvm
+
 namespace tmplang::hir {
 
 class Type {
@@ -8,6 +12,9 @@ public:
   enum Kind { K_Builtin, K_Tuple, K_Subprogram };
 
   Kind getKind() const { return TKind; }
+
+  void print(llvm::raw_ostream &) const;
+  void dump() const;
 
 protected:
   explicit Type(Kind kind) : TKind(kind) {}

--- a/tmplang/lib/Lowering/Lowering.cpp
+++ b/tmplang/lib/Lowering/Lowering.cpp
@@ -51,10 +51,10 @@ private:
   void build(const hir::SubprogramDecl &subprog) {
     DoesThisFuncReturnInAllPaths = false;
 
-    mlir::FunctionType subprogramTy = get(subprog.getSubprogramType());
+    mlir::FunctionType functionTy = get(subprog.getType());
 
     auto subprogramOp = B.create<SubprogramOp>(
-        getLocation(subprog), subprog.getName(), subprogramTy,
+        getLocation(subprog), subprog.getName(), functionTy,
         mlir::SymbolTable::Visibility::Private);
 
     B.setInsertionPointToEnd(&subprogramOp.getBody().getBlocks().front());
@@ -64,8 +64,8 @@ private:
     }
 
     if (!DoesThisFuncReturnInAllPaths) {
-      auto *tuple = dyn_cast<hir::TupleType>(
-          &subprog.getSubprogramType().getReturnType());
+      auto *tuple =
+          dyn_cast<hir::TupleType>(&subprog.getType().getReturnType());
       if (tuple && tuple->isUnit()) {
         auto unkLoc = mlir::UnknownLoc::get(&Ctx);
         auto tupleOp = B.create<TupleOp>(

--- a/tmplang/lib/Sema/Sema.cpp
+++ b/tmplang/lib/Sema/Sema.cpp
@@ -52,7 +52,7 @@ public:
   using SemaAnalysisPass::SemaAnalysisPass;
 
   bool visitSubprogramDecl(const SubprogramDecl &subprogramDecl) {
-    CurrentFuncRetTy = &subprogramDecl.getSubprogramType().getReturnType();
+    CurrentFuncRetTy = &subprogramDecl.getType().getReturnType();
     return true;
   }
 
@@ -84,8 +84,8 @@ public:
 
   bool traverseSubprogramDecl(const SubprogramDecl &subprogramDecl) {
     // If the result type is unit type, there is no need to return in all paths
-    auto *retTy = dyn_cast<hir::TupleType>(
-        &subprogramDecl.getSubprogramType().getReturnType());
+    auto *retTy =
+        dyn_cast<hir::TupleType>(&subprogramDecl.getType().getReturnType());
     if (retTy && retTy->isUnit()) {
       return true;
     }

--- a/tmplang/lib/Tree/HIR/CMakeLists.txt
+++ b/tmplang/lib/Tree/HIR/CMakeLists.txt
@@ -4,6 +4,7 @@ llvm_add_library(TmplangHIRTree
     HIRContext.cpp
     HIRNodeTextPrinter.cpp
     Node.cpp
+    Symbol.cpp
     Types.cpp
 
     LINK_LIBS PUBLIC

--- a/tmplang/lib/Tree/HIR/Decls.cpp
+++ b/tmplang/lib/Tree/HIR/Decls.cpp
@@ -1,6 +1,16 @@
 #include <tmplang/Tree/HIR/Decls.h>
 
+#include <tmplang/Tree/HIR/Symbol.h>
+
 using namespace tmplang::hir;
+
+StringRef Decl::getName() const { return Sym.getId(); }
+const Type &Decl::getType() const { return Sym.getType(); }
+
+const SubprogramType &SubprogramDecl::getType() const {
+  // All subprogram types contains subprogram type
+  return *cast<hir::SubprogramType>(&this->getSymbol().getType());
+}
 
 StringLiteral tmplang::hir::ToString(SubprogramDecl::FunctionKind kind) {
   switch (kind) {

--- a/tmplang/lib/Tree/HIR/HIRContext.cpp
+++ b/tmplang/lib/Tree/HIR/HIRContext.cpp
@@ -3,4 +3,4 @@
 using namespace tmplang::hir;
 
 HIRContext::HIRContext()
-    : i32Type(BuiltinType::Kind::K_i32), UnitType(/*types=*/{}) {}
+    : i32Type(BuiltinType::Kind::K_i32), UnitType(/*types=*/{}), SymM(*this) {}

--- a/tmplang/lib/Tree/HIR/Symbol.cpp
+++ b/tmplang/lib/Tree/HIR/Symbol.cpp
@@ -1,0 +1,90 @@
+#include <tmplang/Tree/HIR/Symbol.h>
+
+#include <llvm/Support/Debug.h>
+#include <llvm/Support/ErrorHandling.h>
+#include <llvm/Support/FormatVariadic.h>
+#include <llvm/Support/raw_ostream.h>
+#include <tmplang/Tree/HIR/Types.h>
+
+#include <cassert>
+
+using namespace tmplang;
+using namespace tmplang::hir;
+
+bool SymbolicScope::isGlobalScope() const { return ParentScope == nullptr; }
+
+const SymbolicScope &SymbolicScope::getContainingScope() const {
+  assert(!isGlobalScope() && "GlobalScope does not have containing scope");
+  return *ParentScope;
+}
+
+bool SymbolicScope::containsSymbol(const Symbol &sym) const {
+  return llvm::find(Symbols, sym) != Symbols.end();
+}
+
+bool SymbolicScope::containsSymbol(SymbolKind kind, llvm::StringRef id) const {
+  return llvm::find_if(Symbols, [=](const Symbol &sym) {
+           return sym.getKind() == kind && sym.getId() == id;
+         }) != Symbols.end();
+}
+
+Symbol &SymbolicScope::addSymbol(Symbol &sym) {
+  return Symbols.emplace_back(sym);
+}
+
+void dumpImpl(const SymbolicScope &scope, bool recursively,
+              unsigned level = 0) {
+  auto *parentScope =
+      scope.isGlobalScope() ? nullptr : &scope.getContainingScope();
+
+  const unsigned numSpaces = level * 2;
+  const std::string spacesStr = std::string(numSpaces, ' ');
+  constexpr const char *headerFmt = "{0}Scope addr: {1}\n"
+                                    "{0}`-> Parent scope: {2}\n";
+
+  llvm::dbgs() << llvm::formatv(headerFmt, spacesStr, &scope, parentScope);
+
+  for (const Symbol &sym : scope.getSymbols()) {
+    constexpr const char *fmt = "{0}  Sym:\n"
+                                "{0}  |-Id: {1}\n"
+                                "{0}  |-Type: {2}\n"
+                                "{0}  `-Kind: {3}\n";
+
+    std::string str;
+    llvm::raw_string_ostream rso(str);
+    sym.getType().print(rso);
+
+    llvm::formatv(fmt, spacesStr, sym.getId(), rso.str(),
+                  ToString(sym.getKind()))
+        .format(llvm::dbgs());
+  }
+
+  llvm::dbgs() << "\n";
+
+  if (recursively && !scope.isGlobalScope()) {
+    dumpImpl(scope.getContainingScope(), recursively, level + 1);
+  }
+}
+
+void SymbolicScope::dump(bool recursively) const {
+  dumpImpl(*this, recursively);
+}
+
+llvm::StringLiteral tmplang::hir::ToString(SymbolKind kind) {
+  switch (kind) {
+  case SymbolKind::Unresolved:
+    return "Unknown";
+  case SymbolKind::Subprogram:
+    return "Subprogram";
+  case SymbolKind::ParamOrVarDecl:
+    return "ParamOrVarDecl";
+  }
+  llvm_unreachable("All cases are covered");
+}
+
+bool Symbol::operator==(const Symbol &otherSym) const {
+  return otherSym.Id == Id && otherSym.Kind == Kind;
+}
+
+Symbol::Symbol(const SymbolicScope &parentScope, const HIRContext &ctx)
+    : Kind(SymbolKind::Unresolved), Ty(TupleType::getUnit(ctx)) {}


### PR DESCRIPTION
Every declaration creates a symbol that could be referenced later. Every Symbol has a hir::Type, a kind and a name. This name, given current language needs, is mandatory but could be optional.

Every Symbol lies in a SymbolicScope. A SymbolicScope is a logical place which it is created per language constructs. SymbolicScopes are nested within other SymbolicScopes, except for the Global SymbolicScope which is created for the CompilationUnit and is the top most.

For now on, every Decl node has a Symbol. Also, HIRBuilder has a stack of SymbolicScope which is used to determine if a Symbol is already declared for the current SymbolicScope.

All Symbols and all SimbolicScopes are allocated in an arena in the HIRContext.