### PR TITLE
Add opt tool

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -1170,8 +1170,6 @@ class VPWidenPointerInductionRecipe : public VPHeaderPHIRecipe {
 
   bool IsScalarAfterVectorization;
 
-  bool IsScalarAfterVectorization;
-
 public:
   /// Create a new VPWidenPointerInductionRecipe for \p Phi with start value \p
   /// Start.

--- a/tmplang/include/tmplang/Lowering/InitTmplang.h
+++ b/tmplang/include/tmplang/Lowering/InitTmplang.h
@@ -1,0 +1,33 @@
+#ifndef TMPLANG_LOWERING_INITTMPLANG_H
+#define TMPLANG_LOWERING_INITTMPLANG_H
+
+#include <mlir/IR/DialectRegistry.h>
+
+// List of Dialects
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <tmplang/Lowering/Dialect/IR/Dialect.h>
+
+// List of Passes
+#include <mlir/Transforms/Passes.h>
+#include <tmplang/Lowering/Conversion/Passes.h>
+
+namespace tmplang {
+
+/// Register all MLIR passes that tmplang depends on
+inline void registerMLIRPassesForTmplang() {
+  mlir::registerCanonicalizerPass();
+}
+
+/// Register all the dialects used by tmplang
+inline void registerDialects(mlir::DialectRegistry &registry) {
+  registry.insert<tmplang::TmplangDialect, mlir::cf::ControlFlowDialect,
+                  mlir::func::FuncDialect, mlir::arith::ArithDialect,
+                  mlir::LLVM::LLVMDialect>();
+}
+
+} // namespace tmplang
+
+#endif // TMPLANG_LOWERING_INITTMPLANG_H

--- a/tmplang/lib/Lowering/Dialect/IR/TmplangOps.cpp
+++ b/tmplang/lib/Lowering/Dialect/IR/TmplangOps.cpp
@@ -172,7 +172,7 @@ mlir::ParseResult AggregateDataAccessOp::parse(mlir::OpAsmParser &parser,
       parser.parseRParen() || parser.parseComma() || parser.parseInteger(idx) ||
       parser.parseColonType(inputTy) || parser.parseArrow() ||
       parser.parseType(accessTy);
-  if (!parsingResult) {
+  if (parsingResult) {
     return mlir::failure();
   }
 
@@ -209,7 +209,7 @@ mlir::ParseResult MatchOp::parse(mlir::OpAsmParser &parser,
       parser.parseRParen() || parser.parseColonType(inputTy) ||
       parser.parseArrow() || parser.parseType(resultTy) ||
       parser.parseRegion(region);
-  if (!parsingResult) {
+  if (parsingResult) {
     return mlir::failure();
   }
 

--- a/tmplang/tools/CMakeLists.txt
+++ b/tmplang/tools/CMakeLists.txt
@@ -16,3 +16,5 @@ target_link_libraries(tmplangc
   LLVMSupport
   LLVMOption
 )
+
+add_subdirectory(tmplang-opt)

--- a/tmplang/tools/tmplang-opt/CMakeLists.txt
+++ b/tmplang/tools/tmplang-opt/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_llvm_executable(tmplang-opt
+  tmplang-opt.cpp
+)
+
+llvm_update_compile_flags(tmplang-opt)
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+
+target_link_libraries(tmplang-opt PRIVATE
+  TmplangMLIRDialect
+  TmplangToArith
+  TmplangToFunc
+  TmplangToLLVM
+
+  MLIRLLVMDialect
+  MLIROptLib
+)

--- a/tmplang/tools/tmplang-opt/tmplang-opt.cpp
+++ b/tmplang/tools/tmplang-opt/tmplang-opt.cpp
@@ -1,0 +1,14 @@
+#include <mlir/Tools/mlir-opt/MlirOptMain.h>
+#include <tmplang/Lowering/InitTmplang.h>
+
+int main(int argc, char **argv) {
+  tmplang::registerMLIRPassesForTmplang();
+  tmplang::registerTmplangPasses();
+
+  mlir::DialectRegistry registry;
+  tmplang::registerDialects(registry);
+
+  llvm::StringRef toolName = "Tmplang modular optimizer driver\n";
+  return mlir::failed(MlirOptMain(argc, argv, toolName, registry,
+                                  /*preloadDialectsInContext=*/false));
+}

--- a/tmplang/tools/tmplangc.cpp
+++ b/tmplang/tools/tmplangc.cpp
@@ -24,7 +24,7 @@ using namespace tmplang;
 
 template <typename PrintConfig_t>
 static std::optional<PrintConfig_t> ParseTreeDumpArg(llvm::opt::Arg &arg,
-                                                CLPrinter &out) {
+                                                     CLPrinter &out) {
   if (arg.getNumValues() == 0) {
     out.errs() << "At least one value of the followings is required: "
                   "'color|addr|loc|all|simple'\n";
@@ -81,7 +81,7 @@ static bool DumpHIR(llvm::opt::Arg &arg, CLPrinter &out,
 }
 
 static std::optional<MLIRPrintingOpsCfg> ParseDumpMLIRArg(llvm::opt::Arg &arg,
-                                                     CLPrinter &out) {
+                                                          CLPrinter &out) {
   constexpr StringLiteral missingDumpOptionMsg =
       "At least one value of the followings is required: "
       "'lower|opt|trans|llvm'\n";


### PR DESCRIPTION
Some example:

`cat out.mlir`
``` mlir
 module @test3.tmp {
   tmplang.subprogram private @foo(%arg0: !tmplang<data "MyData"{i32, i32}>) -> i32 {
     %0 = tmplang.aggregateDataAccess(%arg0), 0 : !tmplang<data "MyData"{i32, i32}> -> i32
     tmplang.return(%0) -> i32
   }
 }
```

`./build/bin/tmplang-opt -convert-tmplang-to-func -convert-tmplang-to-llvm out.mlir`
``` mlir
module @test3.tmp {
  llvm.func @foo(%arg0: !llvm.struct<"MyData", (i32, i32)>) -> i32 {
    %0 = llvm.extractvalue %arg0[0] : !llvm.struct<"MyData", (i32, i32)>
    llvm.return %0 : i32
  }
}
```

Futher reading: https://mlir.llvm.org/getting_started/Debugging/
